### PR TITLE
Refactor education section layout to 3-column grid

### DIFF
--- a/index.html
+++ b/index.html
@@ -666,9 +666,9 @@
     <section id="educacion" class="py-16 section-bg fade-in-section">
         <div class="container mx-auto px-6">
             <h2 class="text-3xl font-bold text-center text-darkgray mb-12">Formación Académica</h2>
-            <div class="grid grid-cols-1 lg:grid-cols-2 gap-8">
+            <div class="grid grid-cols-1 lg:grid-cols-3 gap-8 items-start">
                 <!-- Left: Large Certificaciones Card -->
-                <div class="p-8 bg-gradient-to-br from-blue-50 to-white rounded-xl shadow-lg border border-blue-100 hover-lift">
+                <div class="lg:col-span-2 p-8 bg-gradient-to-br from-blue-50 to-white rounded-xl shadow-lg border border-blue-100 hover-lift">
                     <div class="flex items-center mb-6">
                         <div class="w-12 h-12 bg-primary rounded-lg flex items-center justify-center mr-4">
                             <i class="fas fa-award text-2xl text-white"></i>
@@ -695,19 +695,48 @@
                         <li class="flex items-start"><i class="fas fa-graduation-cap text-gray-500 mr-2 mt-0.5"></i> Requirement Engineering — Udemy</li>
                     </ul>
                 </div>
-                <!-- Right: Educación Universitaria -->
-                <div class="p-6 py-8 bg-gray-50 rounded-xl shadow-lg border border-gray-100 hover-lift">
-                    <div class="flex items-center mb-6">
-                        <div class="w-10 h-10 bg-gray-700 rounded-lg flex items-center justify-center mr-3">
-                            <i class="fas fa-university text-lg text-white"></i>
+                <!-- Right column: stacked compact cards -->
+                <div class="lg:col-span-1 flex flex-col gap-8">
+                    <!-- Educación Universitaria (credencial compacta) -->
+                    <div class="p-6 bg-white rounded-xl shadow-lg border border-gray-100 hover-lift">
+                        <div class="flex items-center mb-5">
+                            <div class="w-10 h-10 bg-gray-700 rounded-lg flex items-center justify-center mr-3">
+                                <i class="fas fa-university text-lg text-white"></i>
+                            </div>
+                            <h3 class="text-xl font-semibold text-primary">Educación Universitaria</h3>
                         </div>
-                        <h3 class="text-xl font-semibold text-primary">Educación Universitaria</h3>
+                        <div class="pl-4 border-l-4 border-primary">
+                            <p class="font-semibold text-darkgray leading-snug">Técnico en Gestión de Empresas</p>
+                            <p class="text-secondary text-sm mt-1">Universidad Nacional de Cuyo — ITU</p>
+                            <div class="flex flex-wrap gap-2 mt-4">
+                                <span class="inline-flex items-center bg-green-50 text-green-700 text-xs font-medium px-3 py-1 rounded-full">
+                                    <i class="fas fa-check-circle mr-1.5"></i> Graduado
+                                </span>
+                                <span class="inline-flex items-center bg-blue-50 text-primary text-xs font-medium px-3 py-1 rounded-full">
+                                    <i class="far fa-calendar mr-1.5"></i> 2017 – 2020
+                                </span>
+                            </div>
+                        </div>
                     </div>
-                    <div class="space-y-6">
-                        <div>
-                            <p class="font-medium text-darkgray">Técnico en Gestión de Empresas (Graduado)</p>
-                            <p class="text-secondary text-sm mt-1">Universidad Nacional de Cuyo - ITU (2017-2020)</p>
+                    <!-- Formación Continua (enfoque de formación) -->
+                    <div class="p-6 bg-gradient-to-br from-blue-50 to-white rounded-xl shadow-lg border border-blue-100 hover-lift">
+                        <div class="flex items-center mb-4">
+                            <div class="w-10 h-10 bg-primary rounded-lg flex items-center justify-center mr-3">
+                                <i class="fas fa-layer-group text-lg text-white"></i>
+                            </div>
+                            <h3 class="text-xl font-semibold text-primary">Formación Continua</h3>
                         </div>
+                        <p class="text-secondary text-sm mb-4">Aprendizaje constante en tecnología y gestión.</p>
+                        <div class="flex flex-wrap gap-2">
+                            <span class="bg-blue-50 text-primary text-sm px-3 py-1 rounded-full">IA &amp; Automatización</span>
+                            <span class="bg-blue-50 text-primary text-sm px-3 py-1 rounded-full">Project Management</span>
+                            <span class="bg-blue-50 text-primary text-sm px-3 py-1 rounded-full">Desarrollo con IA</span>
+                            <span class="bg-blue-50 text-primary text-sm px-3 py-1 rounded-full">Liderazgo &amp; Agile</span>
+                        </div>
+                        <p class="flex items-center text-secondary text-sm mt-5 pt-4 border-t border-gray-200">
+                            <i class="fas fa-graduation-cap text-primary mr-2"></i>
+                            <span><span class="font-semibold text-darkgray">12+</span> cursos y certificaciones</span>
+                        </p>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
Restructured the "Formación Académica" (education) section from a 2-column layout to a 3-column grid with improved visual hierarchy and organization. The large certifications card now spans 2 columns on large screens, while university education and continuous learning are displayed as stacked compact cards in the right column.

## Key Changes
- Changed grid from `lg:grid-cols-2` to `lg:grid-cols-3` with `items-start` alignment
- Certifications card now spans 2 columns (`lg:col-span-2`) to maintain prominence
- Reorganized right column into a flex container (`lg:col-span-1 flex flex-col gap-8`) with two stacked cards:
  - **Educación Universitaria**: Compact card with degree info, institution, graduation status, and year badges
  - **Formación Continua**: New card highlighting continuous learning with skill tags (AI & Automation, Project Management, etc.) and course count summary
- Updated styling for better visual consistency:
  - Changed university card background from `bg-gray-50` to `bg-white`
  - Added left border accent (`border-l-4 border-primary`) to university education details
  - Introduced badge components for status (Graduado) and date range
  - Added gradient background to continuous learning card matching certifications theme

## Implementation Details
- Maintains responsive behavior: single column on mobile, 3-column on large screens
- Uses Tailwind utility classes for spacing, colors, and layout
- Preserves existing hover effects and shadow styling
- All text remains in Spanish per project conventions

https://claude.ai/code/session_012ekCoUUasUYfZC7Tefio4o