### PR TITLE
fix: typewriter del hero trabado al cambiar de idioma

### DIFF
--- a/i18n.js
+++ b/i18n.js
@@ -248,6 +248,13 @@
     // Este listener corre antes que el de index.js (i18n.js se carga primero),
     // así el typewriter lee el texto ya traducido si el idioma guardado es EN.
     document.addEventListener('DOMContentLoaded', () => {
+        // Capturar el español original ANTES de que otros scripts muten el DOM
+        // (el typewriter de index.js reemplaza el contenido de #hero-description;
+        // sin esto, esCache guardaría el markup de la animación a medio tipear)
+        document.querySelectorAll('[data-i18n]').forEach((el) => {
+            const key = el.getAttribute('data-i18n');
+            if (!(key in esCache)) esCache[key] = el.innerHTML;
+        });
         document.querySelectorAll('.lang-toggle').forEach((btn) => {
             btn.addEventListener('click', () => window.i18n.toggle());
         });

--- a/index.js
+++ b/index.js
@@ -5,58 +5,80 @@ document.addEventListener('DOMContentLoaded', () => {
     const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 
     if (heroParagraph && !prefersReducedMotion) {
-        const fullText = heroParagraph.textContent.trim();
-        // El texto completo queda accesible para lectores de pantalla desde el inicio
-        heroParagraph.setAttribute('aria-label', fullText);
-
-        // Placeholder invisible con el texto completo: reserva la altura final
-        // del párrafo para que el tipeo no produzca saltos de layout (CLS)
-        const placeholder = document.createElement('span');
-        placeholder.className = 'invisible';
-        placeholder.setAttribute('aria-hidden', 'true');
-        placeholder.textContent = fullText;
-
-        const typedLayer = document.createElement('span');
-        typedLayer.className = 'absolute inset-0';
-        typedLayer.setAttribute('aria-hidden', 'true');
-
-        const typedText = document.createElement('span');
-        const cursor = document.createElement('span');
-        cursor.className = 'typing-cursor';
-        typedLayer.appendChild(typedText);
-        typedLayer.appendChild(cursor);
-
-        heroParagraph.classList.add('relative');
-        heroParagraph.textContent = '';
-        heroParagraph.appendChild(placeholder);
-        heroParagraph.appendChild(typedLayer);
-
-        let charIndex = 0;
         let typingStarted = false;
+        let typingDone = false;
+        // Identificador de la corrida activa: al cambiar de idioma se incrementa
+        // y los timeouts de la corrida anterior se auto-cancelan.
+        let activeRun = 0;
 
-        function typeNextChar() {
-            // Si el usuario cambió de idioma, i18n reemplazó el contenido del
-            // párrafo y estos nodos quedaron desconectados: cortar el tipeo.
-            if (!typedLayer.isConnected) return;
-            charIndex++;
-            typedText.textContent = fullText.slice(0, charIndex);
-            if (charIndex < fullText.length) {
-                // Cadencia humana: velocidad variable y pausas tras puntuación
-                const lastChar = fullText[charIndex - 1];
-                let delay = 28 + Math.random() * 40;
-                if (lastChar === '.' || lastChar === ',') delay += 250;
-                setTimeout(typeNextChar, delay);
-            } else {
-                // Al terminar, el cursor parpadea un momento y desaparece
-                setTimeout(() => cursor.remove(), 3000);
+        function runTypewriter(initialDelay) {
+            const runId = ++activeRun;
+            typingDone = false;
+            const fullText = heroParagraph.textContent.trim();
+            // El texto completo queda accesible para lectores de pantalla desde el inicio
+            heroParagraph.setAttribute('aria-label', fullText);
+
+            // Placeholder invisible con el texto completo: reserva la altura final
+            // del párrafo para que el tipeo no produzca saltos de layout (CLS)
+            const placeholder = document.createElement('span');
+            placeholder.className = 'invisible';
+            placeholder.setAttribute('aria-hidden', 'true');
+            placeholder.textContent = fullText;
+
+            const typedLayer = document.createElement('span');
+            typedLayer.className = 'absolute inset-0';
+            typedLayer.setAttribute('aria-hidden', 'true');
+
+            const typedText = document.createElement('span');
+            const cursor = document.createElement('span');
+            cursor.className = 'typing-cursor';
+            typedLayer.appendChild(typedText);
+            typedLayer.appendChild(cursor);
+
+            heroParagraph.classList.add('relative');
+            heroParagraph.textContent = '';
+            heroParagraph.appendChild(placeholder);
+            heroParagraph.appendChild(typedLayer);
+
+            let charIndex = 0;
+
+            function typeNextChar() {
+                // Corrida cancelada (cambio de idioma) o nodos desconectados: cortar.
+                if (runId !== activeRun || !typedLayer.isConnected) return;
+                charIndex++;
+                typedText.textContent = fullText.slice(0, charIndex);
+                if (charIndex < fullText.length) {
+                    // Cadencia humana: velocidad variable y pausas tras puntuación
+                    const lastChar = fullText[charIndex - 1];
+                    let delay = 28 + Math.random() * 40;
+                    if (lastChar === '.' || lastChar === ',') delay += 250;
+                    setTimeout(typeNextChar, delay);
+                } else {
+                    // Al terminar, el cursor parpadea un momento y desaparece
+                    typingDone = true;
+                    setTimeout(() => cursor.remove(), 3000);
+                }
             }
+
+            setTimeout(typeNextChar, initialDelay);
         }
 
         function startTyping() {
             if (typingStarted) return;
             typingStarted = true;
-            setTimeout(typeNextChar, 500);
+            runTypewriter(500);
         }
+
+        // Al cambiar de idioma, i18n ya dejó el texto completo traducido en el
+        // párrafo. Si el tipeo estaba en curso, reiniciarlo con el texto nuevo;
+        // si no había empezado o ya terminó, dejar el texto completo visible.
+        document.addEventListener('langchange', () => {
+            if (typingStarted && !typingDone) {
+                runTypewriter(150);
+            } else {
+                activeRun++;
+            }
+        });
 
         if (heroVideo) {
             heroVideo.addEventListener('playing', startTyping, { once: true });


### PR DESCRIPTION
## Resumen
- El typewriter del hero se quedaba trabado (texto parcial + cursor parpadeando para siempre) si el usuario cambiaba de idioma mientras las letras se estaban escribiendo.
- **Causa raíz**: `i18n.js` cacheaba como "español original" el markup de la animación a medio tipear (capturaba el innerHTML recién en el primer cambio de idioma, después de que el typewriter mutara el DOM), y el typewriter se cortaba en silencio sin reaccionar a `langchange`.
- **Fix**: el español se captura en `DOMContentLoaded` antes de cualquier mutación, y el typewriter ahora es reiniciable: al cambiar de idioma retipea el texto traducido si la animación estaba en curso, o deja el texto completo plano si no. El texto nunca puede quedar oculto o parcial.

## Verificación
Probado en navegador con Vite dev server: toggles ES→EN y EN→ES a mitad del tipeo. En ambos sentidos el texto completo queda disponible al instante, la animación reinicia letra a letra en el idioma nuevo, sin duplicados ni mezcla de idiomas, con `aria-label` sincronizado y sin errores de consola.

🤖 Generated with [Claude Code](https://claude.com/claude-code)