### PR TITLE
Habilidades blandas como lista, consistente con las otras cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -552,15 +552,15 @@
                         </div>
                         <h3 class="font-display text-xl font-semibold text-primary" data-i18n="skills.soft.title">Habilidades Blandas</h3>
                     </div>
-                    <div class="flex flex-wrap gap-3">
-                        <span class="inline-flex items-center bg-white border border-gray-200 text-secondary px-4 py-2 rounded-full shadow-sm" data-i18n="skills.soft.s1">Liderazgo de Equipos</span>
-                        <span class="inline-flex items-center bg-white border border-gray-200 text-secondary px-4 py-2 rounded-full shadow-sm" data-i18n="skills.soft.s2">Comunicación Efectiva</span>
-                        <span class="inline-flex items-center bg-white border border-gray-200 text-secondary px-4 py-2 rounded-full shadow-sm" data-i18n="skills.soft.s3">Gestión de Stakeholders</span>
-                        <span class="inline-flex items-center bg-white border border-gray-200 text-secondary px-4 py-2 rounded-full shadow-sm" data-i18n="skills.soft.s4">Resolución de Problemas</span>
-                        <span class="inline-flex items-center bg-white border border-gray-200 text-secondary px-4 py-2 rounded-full shadow-sm" data-i18n="skills.soft.s5">Pensamiento Estratégico</span>
-                        <span class="inline-flex items-center bg-white border border-gray-200 text-secondary px-4 py-2 rounded-full shadow-sm" data-i18n="skills.soft.s6">Negociación</span>
-                        <span class="inline-flex items-center bg-white border border-gray-200 text-secondary px-4 py-2 rounded-full shadow-sm" data-i18n="skills.soft.s7">Adaptabilidad</span>
-                    </div>
+                    <ul class="space-y-2 text-secondary">
+                        <li class="flex items-center" data-i18n="skills.soft.s1">Liderazgo de Equipos</li>
+                        <li class="flex items-center" data-i18n="skills.soft.s2">Comunicación Efectiva</li>
+                        <li class="flex items-center" data-i18n="skills.soft.s3">Gestión de Stakeholders</li>
+                        <li class="flex items-center" data-i18n="skills.soft.s4">Resolución de Problemas</li>
+                        <li class="flex items-center" data-i18n="skills.soft.s5">Pensamiento Estratégico</li>
+                        <li class="flex items-center" data-i18n="skills.soft.s6">Negociación</li>
+                        <li class="flex items-center" data-i18n="skills.soft.s7">Adaptabilidad</li>
+                    </ul>
                 </div>
                 <!-- Right bottom: Gestión de Proyectos -->
                 <div class="p-6 bg-gray-50 rounded-xl shadow hover-lift">


### PR DESCRIPTION
## Resumen
- Convierte las pastillas (pills) de la card **Habilidades Blandas** en una lista de texto (`ul > li`), con el mismo formato que las otras tres cards de la sección de habilidades.
- Mantiene los atributos `data-i18n` de cada ítem, así que la traducción EN sigue funcionando.
- Sin cambios en el CSS embebido: todas las clases usadas ya existen (las usan las otras cards).

🤖 Generated with [Claude Code](https://claude.com/claude-code)